### PR TITLE
Updates for SmugMug API and RSS changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #########################################################################
-# Simple makefile for packaging Roku Flickr application
+# Simple makefile for packaging Roku SmugMug application
 #
 # Makefile Usage:
 # > make
@@ -14,7 +14,9 @@
 # 2) Set the variable ROKU_DEV_TARGET in your environment to the IP 
 #    address of your Roku box. (e.g. export ROKU_DEV_TARGET=192.168.1.1.
 #    Set in your this variable in your shell startup (e.g. .bashrc)
-##########################################################################  
+# 3) If your roku has a password, set the ROKU_DEV_PW environment variable
+#    in order to allow curl requests to authenticate properly for "make install"
+##########################################################################
 PKGREL = ../../packages
 ZIPREL = ../../zips
 SOURCEREL = ..
@@ -56,7 +58,7 @@ roku-smugmug:
 
 install: roku-smugmug
 	@echo "Installing $(APPNAME) to host $(ROKU_DEV_TARGET)"
-	@curl -s -S -F "mysubmit=Install" -F "archive=@$(ZIPREL)/$(APPNAME).zip" -F "passwd=" http://$(ROKU_DEV_TARGET)/plugin_install | grep "<font color" | sed "s/<font color=\"red\">//"
+	@curl -s -S -F "mysubmit=Install" -F "archive=@$(ZIPREL)/$(APPNAME).zip" --anyauth "http://rokudev:$(ROKU_DEV_PW)@$(ROKU_DEV_TARGET)/plugin_install" | grep "<font color" | sed "s/<font color=\"red\">//"
 
 pkg: install
 	@echo "*** Creating Package ***"

--- a/source/private.brs.example
+++ b/source/private.brs.example
@@ -1,0 +1,23 @@
+' *********************************************************
+' *********************************************************
+' **
+' **  Roku DVP SmugMug Channel (BrightScript)
+' **
+' **  C. Hoffman, December 2009
+' **
+' **  Copyright (c) 2009 Chris Hoffman. All Rights Reserved.
+' **
+' *********************************************************
+' *********************************************************
+
+Function getApiKey() As String
+	return "api_key"
+End Function
+
+Function getApiSecret() As String
+	return "api_secret"
+End Function
+
+Function getLinkWebsite() As String
+    return "http://link.example.com"
+End Function

--- a/source/smugmugMain.brs
+++ b/source/smugmugMain.brs
@@ -30,7 +30,7 @@ Sub RunUserInterface()
         for each h in smugmug.highlights:highlights.Push(h):next
         
         if smugmug.isLinked then
-            new_highlights=smugmug.getRandomRssHighlights("http://www.smugmug.com/hack/feed.mg?Type=nicknameRecentPhotos&Data="+smugmug.nickname+"&format=atom10", 1, false)
+            new_highlights=smugmug.getRandomRssHighlights("https://www.smugmug.com/hack/feed.mg?Type=nicknameRecentPhotos&Data="+smugmug.nickname+"&format=atom10", 1, false)
             if new_highlights.Count()>0 then highlights[2]=new_highlights[0]
         end if
         

--- a/source/smugmugRegistration.brs
+++ b/source/smugmugRegistration.brs
@@ -201,7 +201,10 @@ Function checkRegistrationStatus(sn As String, regCode As String) As Integer
     
     while true
         rsp = m.http.GetToString()
-        print rsp
+
+        'print "GOT: " + rsp
+        'print "Reason: " + m.http.GetFailureReason()
+
         xml=ParseXML(rsp)
         if xml=invalid then
             print "Can't parse check registration status response"

--- a/source/smugmugRegistration.brs
+++ b/source/smugmugRegistration.brs
@@ -31,8 +31,8 @@ Function doRegistration() As Integer
         rsp=m.ExecServerAPI("smugmug.auth.getRequestToken")
         m.oauth_token=rsp.auth.token@id
         m.oauth_token_secret=rsp.auth.token@secret
-        
-        sn = CreateObject("roDeviceInfo").GetDeviceUniqueId() 
+
+        sn = CreateObject("roDeviceInfo").GetChannelClientId()
         regCode = m.getRegistrationCode(sn)
         
         'if we've failed to get the registration code, bail out, otherwise we'll

--- a/source/smugmugSettings.brs
+++ b/source/smugmugSettings.brs
@@ -61,8 +61,8 @@ Sub SlideshowSpeed()
 End Sub
 
 Sub DelinkPlayer()
-    ans=ShowDialog2Buttons("Deactivate Player","Remove link to you SmugMug account?","Confirm","Cancel")
-    if ans=0 then 
+    ans=ShowDialog2Buttons("Deactivate Player","Remove link to your SmugMug account?","Confirm","Cancel")
+    if ans=0 then
         RegDelete("oauth_token","Authentication")
         RegDelete("oauth_secret","Authentication")
         m.isLinked=false
@@ -112,8 +112,8 @@ Function GetFollowList()
     for each follow in following
         followReg=strTokenize(RegRead(follow,"Follow"),"|")
         'For backwards compatibility, derive URL
-        if followReg[1]=invalid then followReg[1]="http://"+follow+".smugmug.com"
-        
+        if followReg[1]=invalid then followReg[1]="https://"+follow+".smugmug.com"
+
         ff={nickname: follow, DisplayName: followReg[0], URL: followReg[1]}
         followlist.Push(ff)
     end for

--- a/source/smugmugToolkit.brs
+++ b/source/smugmugToolkit.brs
@@ -113,7 +113,9 @@ Function CreateSmugMugConnection() As Object
         regUrlGetRegResult: "/getRegResult",
         regUrlWebSite: getLinkWebsite(),
     }
-    
+
+    smugmug.http.SetCertificatesFile("common:/certs/ca-bundle.crt")
+
     rsp=smugmug.ExecServerAPI("smugmug.service.ping")
     if not isxmlelement(rsp) then
         return invalid

--- a/source/smugmugToolkit.brs
+++ b/source/smugmugToolkit.brs
@@ -454,7 +454,7 @@ End Function
 
 Function aGetHighlightURL() As String
     if m.xml.highlight@id<>invalid then
-        return m.smugmug.getImageURL(m.xml.highlight@id, m.xml.highlight@key, "S")
+        return m.smugmug.getImageURL(m.xml.highlight@key, "S")
     else if m.HasPassword()=1 then
         return "pkg:/images/smuggy.png"
     else
@@ -569,8 +569,10 @@ Function iIsVideo() As Boolean
     return 0
 End Function
 
-Function getImageURL(image_id, image_key, size="L" As String, ext="jpg" As String) As String
-    url="https://www.smugmug.com/photos/"+image_id+"_"+image_key+"-"+size+"."+ext
+Function getImageURL(image_key, size="L" As String, ext="jpg" As String) As String
+    url="https://photos.smugmug.com/photos/i-"+image_key+"/0/"+size+"/i-"+image_key+"-"+size+"."+ext
+    'print "getImageURL: " url
+    'print "  image_key: " image_key
     return url
 End Function
 
@@ -622,24 +624,24 @@ Function newImageFromRSS(xml As Object) As Object
     image = CreateObject("roAssociativeArray")
     image.xml=xml
     image.GetCaption=function():return m.xml.title.GetText():end function
-    image.GetID=function():return getImageIdFromURL(m.xml.link@href, "id"):end function
-    image.GetKey=function():return getImageIdFromURL(m.xml.link@href, "key"):end function
-    image.GetURL=function(size):return getImageURL(m.GetID(), m.GetKey(), size):end function
+    image.GetKey=function():return getImageKeyFromUrl(m.xml.link@href):end function
+    image.GetURL=function(size):return getImageURL(m.GetKey(), size):end function
     return image
 End Function
 
-'Parse id and key from image URL
-Function getImageIdFromURL(url As String, typ As String) As String
-    'Getting image string (<id>_<key>)
-    image_str=Right(url, Len(url)-InStr(1, url, "#!i=")-3)
+'Extract the image key from a full URL ending in "/i-{KEY}/"
+Function getImageKeyFromUrl(url As String) As String
+    'locate the key prefix "/i-"
+    start_pos=InStr(1, url, "/i-")+2
 
-    'Get id
-    delim_pos=InStr(1, image_str, "&k=")+2
-    if typ="id" then
-        return Left(image_str, delim_pos-1)
-    else if typ="key"
-        return Right(image_str,Len(image_str)-delim_pos)
-    end if
+    'extract from the key position to the end of the string
+    end_str=Right(url, Len(url)-start_pos)
+
+    'locate the first "/" in the remaining string
+    end_pos=InStr(1, end_str, "/")
+
+    'return up to the first "/"
+    return Left(end_str, end_pos-1)
 End Function
 
 Function getImageMetaData(images As Object)

--- a/source/smugmugToolkit.brs
+++ b/source/smugmugToolkit.brs
@@ -195,6 +195,10 @@ Function ExecServerAPI(method, param_list=[] As Object, nickname=invalid As Dyna
     else if m.session_id=invalid then
         m.http.SetUrl(m.endpoint+"?method=smugmug.login.anonymously&APIKey="+m.api_key)
         xml=m.http.GetToString()
+
+        'print "GOT: " + xml
+        'print "Reason: " + m.http.GetFailureReason()
+
         rsp=ParseXML(xml)
         if rsp=invalid then 
             ShowErrorDialog("Error retrieving results","Unable to obtain session")
@@ -218,7 +222,10 @@ Function ExecServerAPI(method, param_list=[] As Object, nickname=invalid As Dyna
     print apiurlstr
     m.http.SetUrl(apiurlstr)
     xml=m.http.GetToString()
-    'print xml
+
+    'print "GOT: " + xml
+    'print "Reason: " + m.http.GetFailureReason()
+
     rsp=ParseXML(xml)
     if rsp=invalid then
         ShowErrorDialog("API return invalid. Try again later","Bad response")
@@ -294,7 +301,10 @@ End Function
 Function ExecRSSRequest(url As String) As Dynamic
     m.http.SetUrl(url)
     xml=m.http.GetToString()
-    'print xml
+
+    'print "GOT: " + xml
+    'print "Reason: " + m.http.GetFailureReason()
+
     rss=ParseXML(xml)
     if rss=invalid then return invalid
     

--- a/source/smugmugToolkit.brs
+++ b/source/smugmugToolkit.brs
@@ -87,7 +87,7 @@ Function CreateSmugMugConnection() As Object
         sha1: function(str,key):sigkey=CreateObject("roByteArray"):sigkey.fromAsciiString(key):ba=CreateObject("roByteArray"):m.hmac.Setup("sha1",sigkey):ba.FromAsciiString(str):return m.hmac.process(ba).toBase64String():end function,
         
         'Oauth
-        endpoint: "http://api.smugmug.com/services/api/rest/1.2.2/",
+        endpoint: "https://api.smugmug.com/services/api/rest/1.3.0/",
         api_key: getApiKey(),
         api_secret: getApiSecret(),
         oauth_signature_method: "HMAC-SHA1",
@@ -98,10 +98,10 @@ Function CreateSmugMugConnection() As Object
         'Url
         urlencodeRFC3986: urlencodeRFC3986,
         urlencodeParams: urlencodeParams,
-        PopularUrlBase: "http://www.smugmug.com/hack/feed.mg?Type=popular&format=atom10&Data=",
-        RandomUrlBase: "http://www.smugmug.com/photos/random.mg?",
-        RecentUrlBase: "http://www.smugmug.com/hack/feed.mg?Type=nicknameRecentPhotos&format=atom10&Data=",
-        
+        PopularUrlBase: "https://www.smugmug.com/hack/feed.mg?Type=popular&format=atom10&Data=",
+        RandomUrlBase: "https://www.smugmug.com/photos/random.mg?",
+        RecentUrlBase: "https://www.smugmug.com/hack/feed.mg?Type=nicknameRecentPhotos&format=atom10&Data=",
+
         'Registration
         doRegistration: doRegistration,
         getRegistrationCode: getRegistrationCode,
@@ -318,7 +318,7 @@ Sub BrowseMySmugMug()
 
     screen=uitkPreShowPosterMenu("","My SmugMug")
 
-    highlights=m.getRandomRssHighlights("http://www.smugmug.com/hack/feed.mg?Type=nicknameRecentPhotos&Data="+m.nickname+"&format=atom10",4)
+    highlights=m.getRandomRssHighlights("https://www.smugmug.com/hack/feed.mg?Type=nicknameRecentPhotos&Data="+m.nickname+"&format=atom10",4)
     for i=0 to 3
         if highlights[i]=invalid then
             highlights[i]="pkg:/images/smuggy.png"
@@ -558,7 +558,7 @@ Function iIsVideo() As Boolean
 End Function
 
 Function getImageURL(image_id, image_key, size="L" As String, ext="jpg" As String) As String
-    url="http://www.smugmug.com/photos/"+image_id+"_"+image_key+"-"+size+"."+ext
+    url="https://www.smugmug.com/photos/"+image_id+"_"+image_key+"-"+size+"."+ext
     return url
 End Function
 
@@ -847,8 +847,8 @@ Sub BrowseSmugmugCategories()
     categories=GetStaticCategories()
     while categories.IsNext()
         category=categories.Next()
-        
-        rsp=m.ExecRSSRequest("http://www.smugmug.com/hack/feed.mg?Type=popularCategory&Data="+m.http.UrlEncode(category)+"&format=atom10")
+
+        rsp=m.ExecRSSRequest("https://www.smugmug.com/hack/feed.mg?Type=popularCategory&Data="+m.http.UrlEncode(category)+"&format=atom10")
         if rsp=invalid then
             ShowErrorDialog("Bad feed response. Try again.","Bad Feed")
             return
@@ -915,7 +915,7 @@ Sub PhotoSearch(searchtype="keyword")
             else if msg.isFullResult()
                 keyword=msg.GetMessage()
                 dialog=ShowPleaseWait("Please wait","Searching images for "+keyword)
-                rsp=m.ExecRSSRequest("http://smugmug.com/hack/feed.mg?Type="+searchtype+"&Data="+m.http.UrlEncode(keyword)+"&format=atom10")
+                rsp=m.ExecRSSRequest("https://smugmug.com/hack/feed.mg?Type="+searchtype+"&Data="+m.http.UrlEncode(keyword)+"&format=atom10")
                 if rsp=invalid then
                     ShowErrorDialog("Bad feed response. Try again.","Bad Feed")
                     return
@@ -1047,7 +1047,7 @@ Sub BrowseFriendsFamily()
         onselect = [1, ff_data[0], m, function(ff, smugmug, set_idx):smugmug.DisplayFriendsFamily(ff[set_idx]):end function]
         uitkDoPosterMenu(m.getFFMetaData(ff_data[0]), screen, onselect)
     else
-        uitkDoMessage("You are not linked to any friends or family.  To find out more about linking to friend and family go to http://www.smugmug.com/help/friends-and-family.", screen)
+        uitkDoMessage("You are not linked to any friends or family.  To find out more about linking to friend and family go to https://www.smugmug.com/help/friends-and-family.", screen)
     end if
 End Sub
 


### PR DESCRIPTION
I've updated the channel source to properly communicate with the updated SmugMug API. The main issues appear to have been that API 1.2.x was replaced with API 1.3.x (which is technically deprecated but will be supported for 1-2 more years), all URLs are now HTTPS, and the image ID/image Key/photo URL construction changed.

I was unable to test it with a linked account, so there could still be complications with displaying albums.

I also repaired the Makefile to communicate with newer Roku software using HTTP Digest authentication & an environment variable for the password.

Unfortunately, I don't know if these changes will be sufficient to get it updated in the channel store. It looks like the code is using deprecated Brightscript components for slideshows, image lists, and poster lists. These all may need to be upgraded to use SceneGraph components, which should probably be a separate PR.